### PR TITLE
chore: cleanups and serde feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,7 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -24,6 +22,8 @@ jobs:
         cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
 
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: |
-        cargo clippy
-        cargo build --verbose
+        cargo clippy --no-deps
+        cargo build --all-targets --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Check semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed #10. Custom implement for `Default`.
+- Fixed #13
+
+### Added 
+- `serde` support for SimpleAccumulator. Enable it using features `serde`
 
 ## [0.5.1] -2023-12-19
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple_accumulator"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = [
   "Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ num = "0.4.1"
 rand = "0.8.5"
 serde = { version = "1.0.193", features = ["derive"] }
 
-[dependencies.float_eq]
-version = "1"
-features = ["derive"]
-
 [profile.release]
 lto = true
 codegen-units = 1
@@ -30,7 +26,4 @@ opt-level = 3
 [dev-dependencies]
 ordered-float = "4.2.0"
 plotly = {version = "0.8.4"}
-
-[lib]
-name = "simple_accumulator"
-
+float_eq = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 name = "simple_accumulator"
 version = "0.5.1"
 edition = "2021"
-authors = ["Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>"]
+authors = [
+  "Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>",
+]
 description = "A simple accumulator for incremental statistical computations"
 repository = "https://github.com/SubconsciousCompute/SimpleAccumulator"
 license = "MIT"
@@ -14,7 +16,7 @@ documentation = "https://docs.rs/simple_accumulator"
 [dependencies]
 num = "0.4.1"
 rand = "0.8.5"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [profile.release]
 lto = true
@@ -23,7 +25,7 @@ opt-level = 3
 
 [dev-dependencies]
 ordered-float = "4.2.0"
-plotly = {version = "0.8.4"}
+plotly = { version = "0.8.4" }
 float_eq = { version = "1", features = ["derive"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/simple_accumulator"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num = "0.4.0"
+num = "0.4.1"
 rand = "0.8.5"
 serde = { version = "1.0.193", features = ["derive"] }
 
@@ -28,8 +28,8 @@ codegen-units = 1
 opt-level = 3
 
 [dev-dependencies]
-ordered-float = "3.7.0"
-plotly = {version = "0.8.3"}
+ordered-float = "4.2.0"
+plotly = {version = "0.8.4"}
 
 [lib]
 name = "simple_accumulator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 name = "simple_accumulator"
 version = "0.6.0"
 edition = "2021"
-authors = [
-  "Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>",
-]
+authors = ["Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>"]
 description = "A simple accumulator for incremental statistical computations"
 repository = "https://github.com/SubconsciousCompute/SimpleAccumulator"
 license = "MIT"
@@ -17,11 +15,6 @@ documentation = "https://docs.rs/simple_accumulator"
 num = "0.4.1"
 rand = "0.8.5"
 serde = { version = "1", features = ["derive"], optional = true }
-
-[profile.release]
-lto = true
-codegen-units = 1
-opt-level = 3
 
 [dev-dependencies]
 ordered-float = "4.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,14 @@
 name = "simple_accumulator"
 version = "0.5.1"
 edition = "2021"
-authors = ["sn99 <siddharthn.099@gmail.com>, purnatag <purnatag@gmail.com>"]
-description = "A simple accumulator"
-repository = "https://github.com/sn99/SimpleAccumulator"
+authors = ["Sid <siddharth.naithani@subcom.tech>, Purnata G <purnata.g@subcom.tech>"]
+description = "A simple accumulator for incremental statistical computations"
+repository = "https://github.com/SubconsciousCompute/SimpleAccumulator"
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/sn99/SimpleAccumulator"
-keywords = ["accumulator", "stats"]
+homepage = "https://github.com/SubconsciousCompute/SimpleAccumulator"
+keywords = ["accumulator", "statistics", "online-algorithms"]
 documentation = "https://docs.rs/simple_accumulator"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 num = "0.4.1"
@@ -27,3 +25,11 @@ opt-level = 3
 ordered-float = "4.2.0"
 plotly = {version = "0.8.4"}
 float_eq = { version = "1", features = ["derive"] }
+
+[features]
+serde = ["dep:serde"]
+
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 all:
-	cargo b --all
-	cargo b --examples
+	cargo b --all-targets
 	
 test:
 	cargo test 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all:
+	cargo b --all
+	cargo b --examples
+	
+test:
+	cargo test 
+
+lint:
+	cargo clippy --all-targets
+
+fix:
+	cargo clippy --fix --allow-dirty
+
+fmt:
+	cargo +nightly fmt

--- a/examples/mean_converge.rs
+++ b/examples/mean_converge.rs
@@ -1,4 +1,4 @@
-use super::SimpleAccumulator;
+use simple_accumulator::SimpleAccumulator;
 use plotly::common::Mode;
 use plotly::{Plot, Scatter};
 use rand::Rng;
@@ -19,9 +19,9 @@ fn main() {
         }
         let mean = acc.buffer_mean;
         let offline_mean = acc.calculate_mean();
-        let error_diff = (offline_mean - mean) / acc.len as f64;
+        let error_diff = (offline_mean - mean) / acc.len() as f64;
         error_mean.push(error_diff * multiplier);
-        len_per_error_mean.push(acc.len as f64);
+        len_per_error_mean.push(acc.len() as f64);
     }
 
     // Plot the error data

--- a/examples/mean_converge.rs
+++ b/examples/mean_converge.rs
@@ -1,0 +1,36 @@
+use super::SimpleAccumulator;
+use plotly::common::Mode;
+use plotly::{Plot, Scatter};
+use rand::Rng;
+
+// fn online_offline_means_converge() {
+fn main() {
+    let mut acc = SimpleAccumulator::new::<f64>(&[], true);
+    let mut error_mean: Vec<f64> = Vec::new();
+    let mut len_per_error_mean: Vec<f64> = Vec::new();
+    let base: i32 = 10;
+    let multiplier = base.pow(5) as f64;
+
+    println!("Waiting to plot the error data...");
+    for _i in 0..1000 {
+        for _j in 0..1000 {
+            let data = rand::thread_rng().gen::<f64>();
+            acc.push(data);
+        }
+        let mean = acc.buffer_mean;
+        let offline_mean = acc.calculate_mean();
+        let error_diff = (offline_mean - mean) / acc.len as f64;
+        error_mean.push(error_diff * multiplier);
+        len_per_error_mean.push(acc.len as f64);
+    }
+
+    // Plot the error data
+    let trace = Scatter::new(len_per_error_mean, error_mean)
+        .name("trace")
+        .mode(Mode::LinesMarkers);
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    plot.show();
+    println!("{}", plot.to_inline_html(Some("error_mean_scatter_plot")));
+}

--- a/examples/mean_converge.rs
+++ b/examples/mean_converge.rs
@@ -1,7 +1,7 @@
-use simple_accumulator::SimpleAccumulator;
 use plotly::common::Mode;
 use plotly::{Plot, Scatter};
 use rand::Rng;
+use simple_accumulator::SimpleAccumulator;
 
 // fn online_offline_means_converge() {
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! Store and update stats related to our data array without iterating again and again
+//! A library for incremental statistical computation inspired by
+//! [Boost.Accumulators](https://www.boost.org/doc/libs/1_84_0/doc/html/accumulators.html).
 //!
 //! ```rust
 //!     let k = [1, 2, 3, 4];
@@ -17,18 +18,13 @@
 //!     println!("{:#?}", x);
 //! ```
 //!
-//! Set field `accumulate` to `false` to not update the value, you will need to run `calculate_all` to
-//! get the updated field values
+//! Set field `accumulate` to `false` to disable online update for statistiscs, you 
+//! will need to run `calculate_all` to get the updated statitics.
 //!
 //! If `with_fixed_capacity` is used then we rewrite the current buffer in FIFO order
 
-#![allow(suspicious_double_ref_op)]
-//pub use self::SimpleAccumulator;
-
 use num::ToPrimitive;
 use std::cmp::Ordering;
-//use float_eq::AssertFloatEq;
-// use std::collections::HashMap;
 
 /// Our main data struct
 #[derive(Clone, Default, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,20 @@
 //!
 //! If `with_fixed_capacity` is used then we rewrite the current buffer in FIFO order
 
-use num::ToPrimitive;
 use std::cmp::Ordering;
+
+use num::ToPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 /// Our main data struct
 #[derive(Clone, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SimpleAccumulator {
     /// Vec to store the data
     pub vec: Vec<f64>,
     /// Vec to privately store mean and three moment differences
+    #[cfg_attr(serde, serde(skip))]
     stats: Vec<f64>,
     /// Running mean
     pub mean: f64,
@@ -42,20 +47,20 @@ pub struct SimpleAccumulator {
     pub total: usize,
     /// Average/mean of the accumulator data
     /// Same as running mean when capacity is not fixed
+    #[cfg_attr(serde, serde(skip))]
     pub(crate) buffer_mean: f64,
     /// Variance of the accumulator data, uses `N` not `N-1`
+    #[cfg_attr(serde, serde(skip))]
     pub(crate) buffer_variance: f64,
-    /*
-    /// (Standard deviation)^2 = variance
-    pub standard_deviation: f64,
-    */
     /// Minimum element in the Accumulator
     pub min: f64,
     /// 2nd lowest value - To help calculate approx min
+    #[cfg_attr(serde, serde(skip))]
     min_: f64,
     /// Maximum element in the Accumulator
     pub max: f64,
     /// 2nd highest value - To help calculate approx max
+    #[cfg_attr(serde, serde(skip))]
     max_: f64,
     /// Middle element. We use a rough estimate when using `accumulate=true`
     pub median: f64,
@@ -64,18 +69,20 @@ pub struct SimpleAccumulator {
     pub len: usize,
     /// Capacity available before it has to reallocate more, doesn't reallocate more if `with_fixed_capacity`
     /// is used - instead rewrites previous places in FIFO order
-    pub capacity: usize,
+    #[cfg_attr(serde, serde(skip))]
+    capacity: usize,
     /// Can only `push` if used, for `pop` and `remove` we return `None`
     pub fixed_capacity: bool,
     /// Gives an idea about last filled position, doesn't get updated if `accumulate=true`
-    pub last_write_position: usize,
+    #[cfg_attr(serde, serde(skip))]
+    last_write_position: usize,
     /// Flag to set whether the fields update or not after a change(push, remove, pop)
     pub accumulate: bool,
     /// Measure of bias in the population. Population follows a Poisson distribution.
     pub skewness: f64,
-    // Measure of the tail length of the distribution
+    /// Measure of the tail length of the distribution
     pub kurtosis: f64,
-    // Measure of two peaks existing in the distribution
+    /// Measure of two peaks existing in the distribution
     pub bimodality: f64,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,12 @@ impl SimpleAccumulator {
         self.vec.len()
     }
 
+    /// Is empty.
+    #[inline]
+    pub fn is_empty(&self) -> usize {
+        self.vec.is_empty()
+    }
+
     /// Get the capacity of underlying container storing data.
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -220,7 +226,7 @@ impl SimpleAccumulator {
     }
 
     pub fn calculate_all(&mut self) {
-        if self.len() == 0 {
+        if self.is_empty() {
             return;
         }
         self.calculate_mean();
@@ -424,7 +430,7 @@ impl SimpleAccumulator {
 
         // we just change the already held value and keep on rewriting it
         if self.fixed_capacity {
-            if self.len() == 0 {
+            if self.is_empty() {
                 self.last_write_position = 0;
             } else {
                 self.last_write_position = (self.last_write_position + 1) % self.capacity();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl SimpleAccumulator {
 
     /// Is empty.
     #[inline]
-    pub fn is_empty(&self) -> usize {
+    pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
     }
 
@@ -627,9 +627,8 @@ impl SimpleAccumulator {
             None
         }
         // When capacity is not fixed and accumulator is non-empty
-        else if self.len() > 0 {
+        else if !self.is_empty() {
             let k = self.vec.pop().unwrap();
-
             if self.accumulate {
                 self.update_fields_decrease(k);
                 self.min_max_update_when_removed(k);

--- a/tests/test_accumulator_fixed.rs
+++ b/tests/test_accumulator_fixed.rs
@@ -10,7 +10,9 @@ use simple_accumulator::SimpleAccumulator;
 #[test]
 fn test_sanity_push_in_fixed_capacity() {
     const CAPACITY: usize = 3;
+    println!("Creating...");
     let mut acc = SimpleAccumulator::with_fixed_capacity::<f64>(&[], CAPACITY, true);
+    println!("{acc:?}");
 
     let data = vec![0.0, 1.1, 2.2, 3.3, 4.4];
     for &v in &data {
@@ -44,6 +46,7 @@ fn test_only_n_recent_values() {
     // Create a SimpleAccumulator for size 10
     const CAPACITY: usize = 10;
     let mut acc = SimpleAccumulator::with_fixed_capacity::<f64>(&[], CAPACITY, true);
+    println!("{acc:?}");
 
     // and push values into it.
     for &v in &data {


### PR DESCRIPTION
- Add serde support but hide it behind feature `serde`
- Cleanup in API. `len` and `capacity` are mapped to `vec.len()` and `vec.capacity()`.
- Other minor cleanups. 
- Moved all tests to `/tests`
- Moved example to `examples/`. Removed duplicate examples.
- Limit many functions visibility to private. more to come in next PR.

cc: @purnatag 