### PR TITLE
feat: Add support for histogram

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: |
-        cargo clippy --no-deps
-        cargo build --all-targets --verbose
+        cargo clippy --no-deps --all-features
+        cargo build --all-targets --all-features --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@v2
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     tags:
       - 'v*'
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Adds
+
+- Adds support for computing histograms (feature 'histogram')
+
 ## [0.6.0] - 2023-12-2023
 ### Fixed
 - Fixed #10. Custom implement for `Default`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ plotly = { version = "0.8.4" }
 float_eq = { version = "1", features = ["derive"] }
 watermill = "0.1.1"
 tracing-test = "0.2.4"
-histogram-sampler = "0.5.0"
 
 [features]
-default = ["histogram"]
+default = []
 serde = ["dep:serde"]
 histogram = ["dep:histogram"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ plotly = { version = "0.8.4" }
 float_eq = { version = "1", features = ["derive"] }
 watermill = "0.1.1"
 tracing-test = "0.2.4"
+histogram-sampler = "0.5.0"
 
 [features]
 default = ["histogram"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ keywords = ["accumulator", "statistics", "online-algorithms"]
 documentation = "https://docs.rs/simple_accumulator"
 
 [dependencies]
+histogram = "0.8.3"
 num-traits = "0.2.17"
 rand = "0.8.5"
 serde = { version = "1", features = ["derive"], optional = true }
+tracing = "0.1.40"
 watermill = "0.1.1"
 
 
@@ -23,6 +25,7 @@ ordered-float = "4.2.0"
 plotly = { version = "0.8.4" }
 float_eq = { version = "1", features = ["derive"] }
 watermill = "0.1.1"
+tracing-test = "0.2.4"
 
 [features]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "simple_accumulator"
 version = "0.6.0"
 edition = "2021"
-authors = ["Sid <siddharth.naithani@subcom.tech>", "Purnata G <purnata.g@subcom.tech>", "Dilawar Singh <dilawar@subcom.tech>"]
+authors = [
+  "Sid <siddharth.naithani@subcom.tech>",
+  "Purnata <purnata.g@subcom.tech>",
+  "Dilawar <dilawar@subcom.tech>",
+]
 description = "A simple accumulator for incremental statistical computations"
 repository = "https://github.com/SubconsciousCompute/SimpleAccumulator"
 license = "MIT"
@@ -12,12 +16,12 @@ keywords = ["accumulator", "statistics", "online-algorithms"]
 documentation = "https://docs.rs/simple_accumulator"
 
 [dependencies]
-histogram = "0.8.3"
 num-traits = "0.2.17"
 rand = "0.8.5"
 serde = { version = "1", features = ["derive"], optional = true }
 tracing = "0.1.40"
 watermill = "0.1.1"
+histogram = { version = "0.8.3", optional = true }
 
 
 [dev-dependencies]
@@ -28,7 +32,9 @@ watermill = "0.1.1"
 tracing-test = "0.2.4"
 
 [features]
+default = ["histogram"]
 serde = ["dep:serde"]
+histogram = ["dep:histogram"]
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub struct SimpleAccumulator<
     fixed_capacity: bool,
 
     /// Histogram
+    #[serde(skip)]
     #[cfg(feature = "histogram")]
     histogram: Option<Histogram>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,10 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
     /// Reference: <https://docs.rs/histogram/latest/histogram/struct.Config.html>
     #[cfg(feature = "histogram")]
     pub fn init_histogram(&mut self, grouping_power: u8, max_value_power: u8) {
+        assert!(
+            grouping_power < max_value_power,
+            "max_value_power must be > grouping_power"
+        );
         if self.histogram.is_some() {
             tracing::info!("Histogram is already initialize. Reinitializing...");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,3 +279,22 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
         self.sum.get()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use num_traits::ToPrimitive;
+
+    #[test]
+    fn test_f32_to_u64() {
+        let a = 40.9f32;
+        let ai = a.to_u64().unwrap();
+        println!("{a} {ai}");
+        assert_eq!(a.floor() as u64, ai);
+
+        for _i in 0..10000 {
+            let a = rand::random::<f64>() * 100.0;
+            let ai = a.to_u64().unwrap();
+            assert_eq!(a.floor() as u64, ai, "floor or {a} is not equal to {ai}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 use std::collections::VecDeque;
 use std::ops::{AddAssign, SubAssign};
 
+use histogram::Histogram;
+
 use num_traits::{cast::FromPrimitive, float::Float};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -68,6 +70,9 @@ pub struct SimpleAccumulator<
 
     /// Can only `push` if used, for `pop` and `remove` we return `None`
     fixed_capacity: bool,
+
+    /// Histogram
+    histogram: Option<Histogram>,
 }
 
 impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
@@ -92,6 +97,31 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
             k.push(v);
         }
         k
+    }
+
+    /// Initialize a histogram The configuration of a histogram which determines the bucketing
+    /// strategy and therefore the relative error and memory utilization of a histogram.
+    ///
+    /// `grouping_power` - controls the number of buckets that are used to span consecutive powers
+    /// of two. Lower values result in less memory usage since fewer buckets will be created.
+    /// However, this will result in larger relative error as each bucket represents a wider range
+    /// of values.  
+    ///
+    /// `max_value_power` - controls the largest value which can be stored in the histogram.
+    /// 2^(max_value_power) - 1 is the inclusive upper bound for the representable range of values.
+    ///
+    /// Reference: <https://docs.rs/histogram/latest/histogram/struct.Config.html>
+    pub fn init_histogram(&mut self, grouping_power: u8, max_value_power: u8) {
+        if self.histogram.is_some() {
+            tracing::info!("Histogram is already initialize. Reinitializing...");
+        }
+        self.histogram = match histogram::Histogram::new(grouping_power, max_value_power) {
+            Ok(hist) => Some(hist),
+            Err(e) => {
+                tracing::warn!("Failed to initialize histogram: {e}");
+                None
+            }
+        }
     }
 
     /// Get the length of underlying container storing data.
@@ -180,6 +210,19 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
             }
         }
         self.data.push_back(y);
+
+        if let Some(histogram) = self.histogram.as_mut() {
+            if let Some(v) = y.to_u64() {
+                if let Err(e) = histogram.increment(v) {
+                    debug_assert!(false, "Failed to increment the histogram: {e}");
+                }
+            }
+        }
+    }
+
+    /// Return reference to the inner Histogram
+    pub fn histogram(&self) -> Option<&histogram::Histogram> {
+        self.histogram.as_ref()
     }
 
     /// Function similar to `append` in `Vec`, rewrites in FIFO order if `fixed_capacity` is 'true'.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 use std::collections::VecDeque;
 use std::ops::{AddAssign, SubAssign};
 
+#[cfg(feature = "histogram")]
 use histogram::Histogram;
 
 use num_traits::{cast::FromPrimitive, float::Float};
@@ -72,6 +73,7 @@ pub struct SimpleAccumulator<
     fixed_capacity: bool,
 
     /// Histogram
+    #[cfg(feature = "histogram")]
     histogram: Option<Histogram>,
 }
 
@@ -111,6 +113,7 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
     /// 2^(max_value_power) - 1 is the inclusive upper bound for the representable range of values.
     ///
     /// Reference: <https://docs.rs/histogram/latest/histogram/struct.Config.html>
+    #[cfg(feature = "histogram")]
     pub fn init_histogram(&mut self, grouping_power: u8, max_value_power: u8) {
         if self.histogram.is_some() {
             tracing::info!("Histogram is already initialize. Reinitializing...");
@@ -221,6 +224,7 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign + std::default::Default>
     }
 
     /// Return reference to the inner Histogram
+    #[cfg(feature = "histogram")]
     pub fn histogram(&self) -> Option<&histogram::Histogram> {
         self.histogram.as_ref()
     }

--- a/tests/test_histogram.rs
+++ b/tests/test_histogram.rs
@@ -1,12 +1,11 @@
 //! Runs the following tests.
 //!
-//! - Check if histogram computed is 'correct'.
+//! 1. Check if histogram computed is 'correct'.
 
 #![cfg(feature = "histogram")]
 
-use histogram_sampler::Sampler;
-use rand::distributions::Distribution;
 use simple_accumulator::SimpleAccumulator;
+use std::ops::Shr;
 use tracing_test::traced_test;
 
 #[traced_test]
@@ -14,21 +13,28 @@ use tracing_test::traced_test;
 fn test_hist_correctness() {
     // create an accumulator with fixed capacity.
     let mut acc = SimpleAccumulator::new(&[0.0], Some(10));
-    acc.init_histogram(8, 8 /* 2^8 is max value */);
+    const N: i64 = 100_000;
 
-    let sampler = Sampler::from_bins(
-        vec![(5, 10), (15, 10), (25, 10), (35, 10)],
-        10, /* bin width */
-    );
-
+    acc.init_histogram(7, 8 /* 2^8 is max value */);
     let mut rng = rand::thread_rng();
-
-    for _i in 0..100 {
-        let a = sampler.sample(&mut rng);
-        print!("{a} ");
+    for _i in 0..N {
+        let a = rand::random::<u8>();
         acc.push(a as f64);
     }
 
-    let hist = acc.histogram();
+    let expected_mean = N / (u8::MAX as i64);
+    let hist = acc.histogram().unwrap().as_slice();
+    let mean = hist.iter().map(|x| *x as i64).sum::<i64>() / (hist.len() as i64);
     println!("computed hist = {hist:?}");
+    println!("expected mean = {expected_mean}, mean={mean}");
+
+    let var = hist.iter().map(|x| (*x as i64 - mean).pow(2)).sum::<i64>() / (hist.len() as i64);
+    let std = (var as f64).powf(0.5);
+    println!("variance={var} std={std}");
+
+    assert!(
+        (mean - expected_mean).abs() < 5,
+        "{mean} is far away from expecte mean {expected_mean}"
+    );
+    assert!(std < 24.0, "Standard deviation is too high {std}");
 }

--- a/tests/test_histogram.rs
+++ b/tests/test_histogram.rs
@@ -1,0 +1,34 @@
+//! Runs the following tests.
+//!
+//! - Check if histogram computed is 'correct'.
+
+#![cfg(feature = "histogram")]
+
+use histogram_sampler::Sampler;
+use rand::distributions::Distribution;
+use simple_accumulator::SimpleAccumulator;
+use tracing_test::traced_test;
+
+#[traced_test]
+#[test]
+fn test_hist_correctness() {
+    // create an accumulator with fixed capacity.
+    let mut acc = SimpleAccumulator::new(&[0.0], Some(10));
+    acc.init_histogram(8, 8 /* 2^8 is max value */);
+
+    let sampler = Sampler::from_bins(
+        vec![(5, 10), (15, 10), (25, 10), (35, 10)],
+        10, /* bin width */
+    );
+
+    let mut rng = rand::thread_rng();
+
+    for _i in 0..100 {
+        let a = sampler.sample(&mut rng);
+        print!("{a} ");
+        acc.push(a as f64);
+    }
+
+    let hist = acc.histogram();
+    println!("computed hist = {hist:?}");
+}


### PR DESCRIPTION
Adds support for computing histogram, hidden behind feature `histogram`.

Uses an excellent crate https://crates.io/crates/histogram that only supports `u64`. `f64` is converted to `u64` (the fractional part is thrown away). 


The user needs to initialize the histogram by calling `init_histogram` otherwise histogram is not compute. Example

```
let mut acc = SimpleAccumulator::new(&[], Some(10)); // with history window of 10
acc.init_histogram(4, 8); // maximum value 2^8, 
acc.push(10.0);
acc.push(11.0);
assert!(acc.histogram().is_some());
``` 